### PR TITLE
Update podSpec to specify tvOS support

### DIFF
--- a/EnvoyAmbassador.podspec
+++ b/EnvoyAmbassador.podspec
@@ -9,6 +9,7 @@ Pod::Spec.new do |spec|
   spec.social_media_url   = 'https://twitter.com/fangpenlin'
   spec.ios.deployment_target = '8.0'
   spec.osx.deployment_target = '10.10'
+  spec.tvos.deployment_target = '11.0'
   spec.source       = {
     git: 'https://github.com/envoy/Ambassador.git',
     tag: "v#{spec.version}"


### PR DESCRIPTION
Resolve validation error on pod repo push or install for tvOS apps.
   - ERROR | [tvOS] unknown: Encountered an unknown error (The platform of the target `App` (tvOS 11.0) is not compatible with `EnvoyAmbassador (4.0.3)`, which does not support `tvos`.) during validation.