### PR TITLE
Xcode 14 fix, use Embassy version 4.1.4

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
         .library(name: "Ambassador", targets: ["Ambassador"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/envoy/Embassy.git", from: "4.0.5")
+        .package(url: "https://github.com/envoy/Embassy.git", from: "4.1.4")
     ],
     targets: [
         .target(name: "Ambassador", dependencies: ["Embassy"], path: "Ambassador"),


### PR DESCRIPTION
Embassy v4.1.4 fixes [Xcode 14 crash](https://github.com/envoy/Embassy/pull/100)